### PR TITLE
Add :Jserve to launch a local server

### DIFF
--- a/doc/jekyll.txt
+++ b/doc/jekyll.txt
@@ -84,18 +84,32 @@ blog.
                     Gemfile; if found `bundle exec` is used to run the
                     `jekyll` command. The blog will be built with: >
 
-            jekyll --no-auto --no-server BLOG_ROOT BLOG_ROOT/SITE_DIR <args>
+                    jekyll build -s BLOG_ROOT -d BLOG_ROOT/SITE_DIR <args>
 <
                     If this doesn't fit your situation, you can set a custom
                     command with |g:jekyll_build_command|. When using a custom
                     command no check for a Gemfile is performed.
+
+                                                *jekyll-:Jserve*
+:Jserve [{args}]    Serve blog. This will check for the presence of a
+                    Gemfile; if found `bundle exec` is used to run the
+                    `jekyll` command. The blog will be served with: >
+
+                    jekyll serve -s BLOG_ROOT -d BLOG_ROOT/SITE_DIR <args>
+<
+                    If this doesn't fit your situation, you can set a custom
+                    command with |g:jekyll_serve_command|. When using a custom
+                    command no check for a Gemfile is performed.
+
+                    The server is run inline. Use Ctrl-C to exit and resume
+                    editing.
 
 ==============================================================================
 ABOUT                                           *jekyll-about*
 
 Grab the latest version or report a bug on Github:
 
-https://github.com/itspriddle/vim-jekyll/
+https://github.com/parkr/vim-jekyll/
 
                                                 *jekyll-license*
 Distributed under the same terms as Vim itself. See |license|.

--- a/plugin/jekyll.vim
+++ b/plugin/jekyll.vim
@@ -182,8 +182,8 @@ function! s:open_post(create, cmd, ...)
 endfunction
 
 " Return the command used to build the blog.
-function! s:jekyll_bin()
-  let bin = 'jekyll build '
+function! s:jekyll_bin(subcmd)
+  let bin = 'jekyll '.a:subcmd.' '
 
   if filereadable(b:jekyll_root_dir.'/Gemfile')
     let bin = 'bundle exec '.bin
@@ -198,11 +198,29 @@ function! s:jekyll_build(cmd)
   if exists('g:jekyll_build_command') && ! empty(g:jekyll_build_command)
     let bin = g:jekyll_build_command
   else
-    let bin = s:jekyll_bin()
+    let bin = s:jekyll_bin('build')
   endif
 
   echo 'Building, this may take a moment'
   let lines = system(bin.' '.a:cmd)
+
+  if v:shell_error != 0
+    return s:error('Build failed')
+  else
+    echo 'Site built!'
+  endif
+endfunction
+
+" Return 'jekyll' or 'bundle exec jekyll'
+function! s:jekyll_serve(cmd)
+  if exists('g:jekyll_serve_command') && ! empty(g:jekyll_serve_command)
+    let bin = g:jekyll_serve_command
+  else
+    let bin = s:jekyll_bin('serve')
+  endif
+
+  echo 'Serving at http://localhost:4000 ...'
+  let lines = system(bin.' -P 4000 '.a:cmd)
 
   if v:shell_error != 0
     return s:error('Build failed')
@@ -232,6 +250,7 @@ function! s:register_commands()
   endfor
 
   call s:define_command('-nargs=* Jbuild call s:jekyll_build("<args>")')
+  call s:define_command('-nargs=* Jserve call s:jekyll_serve("<args>")')
 endfunction
 
 " Try to locate the _posts directory


### PR DESCRIPTION
Run `:Jserve` to boot up a Jekyll server at `localhost:4000` for viewing. Hit `Ctrl-C` to exit.
